### PR TITLE
Provide correct method for obtaining an RID

### DIFF
--- a/classes/class_stylebox.rst
+++ b/classes/class_stylebox.rst
@@ -176,7 +176,7 @@ Method Descriptions
 
 Draws this stylebox using a :ref:`CanvasItem<class_CanvasItem>` with given :ref:`RID<class_RID>`.
 
-You can get a :ref:`RID<class_RID>` value using :ref:`Object.get_instance_id<class_Object_method_get_instance_id>` on a :ref:`CanvasItem<class_CanvasItem>`-derived node.
+You can get a :ref:`RID<class_RID>` value using :ref:`get_canvas_item<class_CanvasItem_method_get_canvas_item>` on a :ref:`CanvasItem<class_CanvasItem>`-derived node.
 
 ----
 


### PR DESCRIPTION
Object.get_instance_id returns an int, and it's not clear how this can be used to obtain an RID. The get_canvas_item method is the simplest way of obtaining a valid RID in this context.

<!--
**Note:** Pull Requests should be made against the `master` by default.

Only make Pull Requests against other branches (e.g. `2.1`) if your changes only apply to that specific version of Godot.

The type of content accepted into the documentation is explained here: https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html

-->
